### PR TITLE
fix: resolve pub.dev validation issues

### DIFF
--- a/.github/workflows/pusblish.yml
+++ b/.github/workflows/pusblish.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   publish:
+    environment: production
     permissions:
       id-token: write
     runs-on: ubuntu-latest

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/caraousel_indicator.dart
+++ b/lib/caraousel_indicator.dart
@@ -193,7 +193,7 @@ class CarouselDotIndicator extends BaseCarouselIndicator {
     final theme = Theme.of(context);
     final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
     final effectiveInactiveColor =
-        inactiveColor ?? theme.colorScheme.onSurface.withOpacity(0.24);
+        inactiveColor ?? theme.colorScheme.onSurface.withAlpha(61);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -267,7 +267,7 @@ class CarouselBarIndicator extends BaseCarouselIndicator {
     final theme = Theme.of(context);
     final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
     final effectiveInactiveColor =
-        inactiveColor ?? theme.colorScheme.onSurface.withOpacity(0.24);
+        inactiveColor ?? theme.colorScheme.onSurface.withAlpha(61);
     final effectiveBorderRadius =
         borderRadius ?? BorderRadius.circular(height / 2);
 
@@ -335,7 +335,7 @@ class CircularIndicator extends BaseCarouselIndicator {
     final theme = Theme.of(context);
     final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
     final effectiveInactiveColor =
-        inactiveColor ?? theme.colorScheme.onSurface.withOpacity(0.24);
+        inactiveColor ?? theme.colorScheme.onSurface.withAlpha(61);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -407,7 +407,7 @@ class SequentialFillIndicator extends BaseCarouselIndicator {
     final theme = Theme.of(context);
     final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
     final effectiveInactiveColor =
-        inactiveColor ?? theme.colorScheme.onSurface.withOpacity(0.24);
+        inactiveColor ?? theme.colorScheme.onSurface.withAlpha(61);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -477,7 +477,7 @@ class ExpandingDotIndicator extends BaseCarouselIndicator {
     final theme = Theme.of(context);
     final effectiveActiveColor = activeColor ?? theme.colorScheme.primary;
     final effectiveInactiveColor =
-        inactiveColor ?? theme.colorScheme.onSurface.withOpacity(0.24);
+        inactiveColor ?? theme.colorScheme.onSurface.withAlpha(61);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/flutter_custom_caraousel_v2.dart
+++ b/lib/flutter_custom_caraousel_v2.dart
@@ -497,13 +497,16 @@ class CarouselViewV2State extends State<CarouselViewV2>
         widget.overlayColor ??
             WidgetStateProperty.resolveWith((Set<WidgetState> states) {
               if (states.contains(WidgetState.pressed)) {
-                return theme.colorScheme.onSurface.withOpacity(0.1);
+                return theme.colorScheme.onSurface
+                    .withAlpha(26); // 0.1 opacity ≈ alpha 26
               }
               if (states.contains(WidgetState.hovered)) {
-                return theme.colorScheme.onSurface.withOpacity(0.08);
+                return theme.colorScheme.onSurface
+                    .withAlpha(20); // 0.08 opacity ≈ alpha 20
               }
               if (states.contains(WidgetState.focused)) {
-                return theme.colorScheme.onSurface.withOpacity(0.1);
+                return theme.colorScheme.onSurface
+                    .withAlpha(26); // 0.1 opacity ≈ alpha 26
               }
               return null;
             });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_custom_caraousel_v2
-description: "A customizable, feature-rich carousel implementation for Flutter that follows Material Design 3 principles. This package supports multiple carousel layouts, autoplay functionality, custom indicators, and full controller capabilities."
-version: 0.0.1
+description: "A customizable carousel for Flutter with Material Design 3 support, multiple layouts and indicator styles."
+version: 0.1.0
 homepage: https://pub.dev/packages/flutter_custom_caraousel_v2
 repository: https://github.com/adampermana/flutter_custom_caraousel_v2
 issue_tracker: https://github.com/adampermana/flutter_custom_caraousel_v2/issues


### PR DESCRIPTION
# Pull Request Template

## Status
READY

## Breaking Changes
NO

## Description
This PR fixes validation issues for pub.dev scoring by replacing deprecated color methods and shortening the package description to meet requirements.

## Related PRs
None

## Todos
- [x] Tests (all tests are passing)
- [x] Documentation (updated package description)
- [x] Examples (existing examples are working)

## Steps to Test or Reproduce
1. Run `flutter analyze` to verify no linting issues
2. Run `dart pub publish --dry-run` to verify no pub.dev validation issues
3. Check that carousel rendering still works correctly with the new color alpha methods

## Impact to Remaining Code Base
This PR will affect:
- Color opacity handling in the carousel indicator component
- Package metadata in pubspec.yaml